### PR TITLE
Fix naming error on Equal/Refl.kind2

### DIFF
--- a/Equal/Refl.kind2
+++ b/Equal/Refl.kind2
@@ -1,1 +1,0 @@
-Equal.refl <t> <a: t> : (Equal t a a)

--- a/Equal/refl.kind2
+++ b/Equal/refl.kind2
@@ -1,0 +1,1 @@
+Equal.refl <t> <a: t> : (Equal t a a)

--- a/Nat/assoc.kind2
+++ b/Nat/assoc.kind2
@@ -1,0 +1,16 @@
+Nat.assoc (a: Nat) (b: Nat) (c: Nat): (Equal (Nat.add a (Nat.add b c)) (Nat.add (Nat.add a b) c))
+Nat.assoc Nat.zero b c = 
+	// Base case. 
+	// If a == 0, then (a + b) = b and a + (b + c) = (b + c).
+	// Kind2 knows this because of the definition of addition.
+	// So our goal is (b + c) == (b + c), and this is trivial to prove because of Equal.refl
+	Equal.refl
+Nat.assoc (Nat.succ a) b c = 
+	// Proof by induction.
+	// (Nat.add.assoc a b c) tells us that a + (b + c) = (a + b) + c
+	// We want (a + 1) + (b + c) = ((a + 1) + b) + c
+	// Thanks to the definition of addition, Kind2 takes the "+ 1" out of our goal and it turns into
+	// (a + (b + c)) + 1 = ((a + b) + c) + 1
+	// So now, we can simply apply "+ 1" (which is Nat.succ) on both sides
+	// to reach our goal
+	(Equal.apply @x(Nat.succ x) (Nat.assoc a b c))


### PR DESCRIPTION
I also added a proof of addition's associative property.

`Equal/Refl.kind2` should be named `Equal/refl.kind2` to allow looking up the name automatically. The uppercase name only works on Windows because Windows has case-insensitive filenames. It does not work on Linux because when the compiler looks for `Equal/refl.kind2` the OS returns a "file not found" error.